### PR TITLE
fix: move geckodriver binary install into gecko-driver.install

### DIFF
--- a/debian/gecko-driver.install
+++ b/debian/gecko-driver.install
@@ -1,2 +1,3 @@
+debian/tmp/geckodriver	usr/bin/
 gecko-driver.svg	usr/share/icons/hicolor/scalable/apps/
 org.mozilla.gecko_driver.metainfo.xml	usr/share/metainfo/

--- a/debian/install
+++ b/debian/install
@@ -1,1 +1,0 @@
-debian/tmp/geckodriver /usr/bin


### PR DESCRIPTION
## Summary

- `debian/install` was being silently ignored because debhelper uses the package-specific `debian/gecko-driver.install` when it exists
- The `geckodriver` binary install line was only in `debian/install`, so it never got installed — causing `dh_missing` to abort the build
- Merged the binary path into `debian/gecko-driver.install` and removed the now-redundant `debian/install`

## Test plan

- [ ] Trigger Jenkins build and confirm `dh_missing` no longer errors on `geckodriver`
- [ ] Verify `/usr/bin/geckodriver` is present in the resulting `.deb`

🤖 Generated with [Claude Code](https://claude.com/claude-code)